### PR TITLE
Linkvalidator task with predefined configuration

### DIFF
--- a/typo3/sysext/linkvalidator/Classes/Task/ValidatorTaskAdditionalFieldProvider.php
+++ b/typo3/sysext/linkvalidator/Classes/Task/ValidatorTaskAdditionalFieldProvider.php
@@ -37,7 +37,7 @@ class ValidatorTaskAdditionalFieldProvider implements \TYPO3\CMS\Scheduler\Addit
 		$additionalFields = array();
 		if (empty($taskInfo['configuration'])) {
 			if ($schedulerModule->CMD == 'add') {
-				$taskInfo['configuration'] = '';
+				$taskInfo['configuration'] = "mod.tx_linkvalidator {\n}";
 			} elseif ($schedulerModule->CMD == 'edit') {
 				$taskInfo['configuration'] = $task->getConfiguration();
 			} else {
@@ -121,7 +121,7 @@ class ValidatorTaskAdditionalFieldProvider implements \TYPO3\CMS\Scheduler\Addit
 			'label' => $label
 		);
 		$fieldId = 'task_configuration';
-		$fieldCode = '<textarea  name="tx_scheduler[linkvalidator][configuration]" id="' . $fieldId . '" >' .
+		$fieldCode = '<textarea  name="tx_scheduler[linkvalidator][configuration]" id="' . $fieldId . '" class="wide">' .
 					htmlspecialchars($taskInfo['configuration']) . '</textarea>';
 		$label = $GLOBALS['LANG']->sL('LLL:EXT:linkvalidator/Resources/Private/Language/locallang.xlf:tasks.validate.conf');
 		$label = BackendUtility::wrapInHelp('linkvalidator', $fieldId, $label);


### PR DESCRIPTION
Added an empty mod.tx_linkvalidator{} to the link validator task configuration to make it easier for newbies to change the configuration (i. e. sender address).