### PR TITLE
Open graph meta tags

### DIFF
--- a/typo3/sysext/frontend/Classes/Page/PageGenerator.php
+++ b/typo3/sysext/frontend/Classes/Page/PageGenerator.php
@@ -1174,8 +1174,13 @@ class PageGenerator {
 			}
 			if ($value !== '') {
 				$attribute = 'name';
-				if ( (is_array($properties) && !empty($properties['httpEquivalent'])) || strtolower($key) === 'refresh') {
-					$attribute = 'http-equiv';
+				if (is_array($properties)) {
+					if (!empty($properties['httpEquivalent']) || strtolower($key) === 'refresh') {
+						$attribute = 'http-equiv';
+					}
+					elseif (!empty($properties['property'])) {
+						$attribute = 'property';
+					}
 				}
 				$metaTags[] = '<meta ' . $attribute . '="' . $key . '" content="' . htmlspecialchars($value) . '"' . $endingSlash . '>';
 			}


### PR DESCRIPTION
Added possibility to write open graph meta tags through typoscript.

Example: 
page.meta {
  og:title = Page title
  og:title.property = 1
}