### PR TITLE
[TASK] Document PHP requirements for TYPO3 CMS 7.5.0-dev(8f540ff)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,6 +109,8 @@ functionality:
   * version 5.5 or later
   * memory_limit set to at least 128M
   * max_execution_time set to at least 240s
+  * max_input_vars set to at least 1500
+  * always_populate_raw_post_data set to -1
 
 * Additional PHP extensions:
   * PHP opcode cache, i.e.: apc, xcache, eaccelerator, Zend Optimizer,


### PR DESCRIPTION
Document PHP requirements to make PHP requirement tests
(performed by TYPO3's install tool) go green. When applied,
users don't run into warnings during installation procedure
of TYPO3 7.4.0 and TYPO3 7.5.0-dev(8f540ff).

Releases: master
Depends: bd72f9a5f238b7f5c6d66a002e138e1fd17705b7
Depends: 91a7c79b92cfe3b874ea7df5069a7bfea8f7e791