### PR TITLE
[BUGFIX] Indexed_search: $view has no method getModuleTemplate on del…

### DIFF
--- a/typo3/sysext/indexed_search/Classes/Controller/AdministrationController.php
+++ b/typo3/sysext/indexed_search/Classes/Controller/AdministrationController.php
@@ -90,9 +90,12 @@ class AdministrationController extends ActionController
         parent::initializeView($view);
         $permissionClause = $this->getBackendUserAuthentication()->getPagePermsClause(1);
         $pageRecord = BackendUtility::readPageAccess($this->pageUid, $permissionClause);
-        $view->getModuleTemplate()->getDocHeaderComponent()->setMetaInformation($pageRecord);
-        $this->generateMenu();
-        $this->view->getModuleTemplate()->setFlashMessageQueue($this->controllerContext->getFlashMessageQueue());
+
+        if (method_exists($view, 'getModuleTemplate')) {
+            $view->getModuleTemplate()->getDocHeaderComponent()->setMetaInformation($pageRecord);
+            $this->generateMenu();
+            $this->view->getModuleTemplate()->setFlashMessageQueue($this->controllerContext->getFlashMessageQueue());
+        }
     }
 
     /**


### PR DESCRIPTION
…eting an indexation

If you want to delete a record, this error message occurs:

Fatal error: Call to a member function getDocHeaderComponent() on a non-object in .../typo3_src/typo3/sysext/indexed_search/Classes/Controller/AdministrationController.php on line 94

The Merge Request fixes the problem, but it should probably be repaired better.