### PR TITLE
Fixed toggling problem on nested sections when using FluidTypo3

### DIFF
--- a/typo3/sysext/backend/Resources/Public/JavaScript/FormEngineFlexForm.js
+++ b/typo3/sysext/backend/Resources/Public/JavaScript/FormEngineFlexForm.js
@@ -109,6 +109,7 @@ define(['jquery',
 
 				// allow the toggle open/close of the main selection
 				me.$el.on('click', opts.sectionToggleButtonSelector, function(evt) {
+					evt.stopPropagation();
 					evt.preventDefault();
 					var $sectionEl = $(this).closest(opts.sectionSelector);
 					me.toggleSection($sectionEl);


### PR DESCRIPTION
Added evt.stopPropagation in click function when toggling nested section
objects to prevent from firing click event twice.