### PR TITLE
Bugfix: Order by integerVersion instead of version

### DIFF
--- a/typo3/sysext/extensionmanager/Classes/Domain/Repository/ExtensionRepository.php
+++ b/typo3/sysext/extensionmanager/Classes/Domain/Repository/ExtensionRepository.php
@@ -93,7 +93,7 @@ class ExtensionRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     {
         $query = $this->createQuery();
         $query->matching($query->logicalAnd($query->equals('extensionKey', $extensionKey), $query->greaterThanOrEqual('reviewState', 0)));
-        $query->setOrderings(['version' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_DESCENDING]);
+        $query->setOrderings(['integerVersion' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_DESCENDING]);
         return $query->execute();
     }
 


### PR DESCRIPTION
findByExtensionKeyOrderedByVersion orders the results by column 'version', which is a varchar. This fails with e.g. the version numbers "1.9.2" and "1.10.0".

Ordering by column "integerVersion" is a whole lot more correct. The bug is present in v6.2, v7.6 and v.8.4 - I have not checked further back.