### PR TITLE
Fix Compatibility of FailsafePackagemanager with Packagemanager

### DIFF
--- a/typo3/sysext/core/Classes/Package/FailsafePackageManager.php
+++ b/typo3/sysext/core/Classes/Package/FailsafePackageManager.php
@@ -60,12 +60,13 @@ class FailsafePackageManager extends \TYPO3\CMS\Core\Package\PackageManager {
 	/**
 	 * Requires and registers all packages which were defined in packageStatesConfiguration
 	 *
+	 * @param boolean $registerOnlyNewPackages
 	 * @return void
 	 * @throws \TYPO3\Flow\Package\Exception\CorruptPackageException
 	 */
-	protected function registerPackagesFromConfiguration() {
+	protected function registerPackagesFromConfiguration($registerOnlyNewPackages = FALSE) {
 		$this->packageStatesConfiguration['packages']['install']['state'] = 'active';
-		parent::registerPackagesFromConfiguration();
+		parent::registerPackagesFromConfiguration($registerOnlyNewPackages);
 	}
 
 	/**


### PR DESCRIPTION
Fix Warning: Declaration of TYPO3\CMS\Core\Package\FailsafePackageManager::registerPackagesFromConfiguration() should be compatible with TYPO3\CMS\Core\Package\PackageManager::registerPackagesFromConfiguration($registerOnlyNewPackages = false) in /var/www/sources/typo3_src-6.2.30/typo3/sysext/core/Classes/Package/FailsafePackageManager.php on line 24