### PR TITLE
Fix syntax error

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/8.1/Breaking-75454-LocalConfigurationDBConfigStructureHasChanged.rst
+++ b/typo3/sysext/core/Documentation/Changelog/8.1/Breaking-75454-LocalConfigurationDBConfigStructureHasChanged.rst
@@ -27,7 +27,7 @@ The new configuration array structure:
 				'host' => '127.0.0.1',
 				'port' => 3306,
 				'user' => 'typo3',
-				'socket' => ''
+				'socket' => '',
 				'charset' => 'utf-8',
 			],
 		],


### PR DESCRIPTION
As some might copy and paste the configuration structure, there should be no syntax error.
Therefore the missing comma was added.