### PR TITLE
Fix broken identifier

### DIFF
--- a/typo3/sysext/form/Documentation/Concepts/FrontendRendering/Index.rst
+++ b/typo3/sysext/form/Documentation/Concepts/FrontendRendering/Index.rst
@@ -329,7 +329,7 @@ Override the option using the ``form definition``:
 
     finishers:
       -
-        identifier: Custom
+        identifier: CustomFinisher
         options:
           yourCustomOption: 'Björn'
 


### PR DESCRIPTION
As identifier is defined as CustomFinisher above, the same has to be used in the lower example.