### PR TITLE
[TASK] Fix broken validation translation form docs

### DIFF
--- a/typo3/sysext/form/Documentation/Concepts/FrontendRendering/Index.rst
+++ b/typo3/sysext/form/Documentation/Concepts/FrontendRendering/Index.rst
@@ -1004,9 +1004,9 @@ are valid. Read more about :ref:`concrete validator configurations <typo3.cms.fo
 The look-up process searches for translation keys in all given translation
 files based on the following order:
 
-- ``<formDefinitionIdentifier>.validation.<elementIdentifier>.<validationErrorCode>``
-- ``<formDefinitionIdentifier>.validation.<validationErrorCode>``
-- ``validation.<validationErrorCode>``
+- ``<formDefinitionIdentifier>.validation.error.<elementIdentifier>.<validationErrorCode>``
+- ``<formDefinitionIdentifier>.validation.error.<validationErrorCode>``
+- ``validation.error.<validationErrorCode>``
 
 
 Example
@@ -1043,9 +1043,9 @@ name", the ``NotEmpty`` validator fails. Now, the look-up process searches
 for the following translation keys for the ``NotEmpty`` validator combined
 with the form element ``LastName``:
 
-- ContactForm.validation.LastName.1221560910
-- ContactForm.validation.1221560910
-- validation.1221560910
+- ContactForm.validation.error.LastName.1221560910
+- ContactForm.validation.error.1221560910
+- validation.error.1221560910
 
 As mentioned above, if there is no corresponding translation key available,
 the default message of the Extbase framework will be shown.


### PR DESCRIPTION
The TranslationService uses the additional key 'error' in its translations of the validation errors.

This can be seen in https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/form/Classes/Service/TranslationService.php#L428.