### PR TITLE
[BUGFIX] automatic overflow does not work for lists

### DIFF
--- a/typo3/sysext/fluid_styled_content/Configuration/TypoScript/Styling/setup.txt
+++ b/typo3/sysext/fluid_styled_content/Configuration/TypoScript/Styling/setup.txt
@@ -37,7 +37,7 @@ plugin.tx_frontend._CSS_DEFAULT_STYLE (
 
     .ce-above .ce-bodytext { clear: both; }
 
-    .ce-intext.ce-left ol, .ce-intext.ce-left ul { padding-left: 40px; overflow: auto; }
+    .ce-intext.ce-left ol, .ce-intext.ce-left ul { padding-left: 40px; }
 
     /* Headline */
     .ce-headline-left { text-align: left; }


### PR DESCRIPTION
This is how it looks with overflow:auto
https://codepen.io/anon/pen/WEqdVd

And this is how it looks without overflow:auto
https://codepen.io/anon/pen/rzEJBo

Expected: list elements should go around the image.