### PR TITLE
[BUGFIX] Prevent javascript error in backend

### DIFF
--- a/typo3/sysext/backend/Resources/Public/JavaScript/LiveSearch.js
+++ b/typo3/sysext/backend/Resources/Public/JavaScript/LiveSearch.js
@@ -127,11 +127,13 @@ define([
 			TYPO3.ModuleMenu.App.showModule('web_list', 'id=0&search_levels=-1&search_field=' + encodeURIComponent($(searchFieldSelector).val()));
 			$(searchFieldSelector).val('').trigger('change');
 		});
-		$('.' + $(searchFieldSelector).autocomplete().options.containerClass).on('click.autocomplete', '.dropdown-list-link', function(evt) {
-			evt.preventDefault();
-			jump($(this).data('target'), 'web_list', 'web', $(this).data('pageid'));
-			$(searchFieldSelector).val('').trigger('change');
-		});
+		if ($(searchFieldSelector).length) {
+			$('.' + $(searchFieldSelector).autocomplete().options.containerClass).on('click.autocomplete', '.dropdown-list-link', function (evt) {
+				evt.preventDefault();
+				jump($(this).data('target'), 'web_list', 'web', $(this).data('pageid'));
+				$(searchFieldSelector).val('').trigger('change');
+			});
+		}
 
 		// Unset height, width and z-index
 		$(toolbarItem).removeAttr('style');


### PR DESCRIPTION
When you have a backend user without permissions on the
search, you get JS errors because the autocomplete can not be
initialized.

This PR just fixes the autocomplete error.

Change-Id: If2827902443ff7411d9b2c1050213be3e0d78fb6
Related: #82969