### PR TITLE
[BUGFIX] Correct css class on success button.

### DIFF
--- a/typo3/sysext/install/Resources/Private/Templates/Installer/ShowEnvironmentAndFolders.html
+++ b/typo3/sysext/install/Resources/Private/Templates/Installer/ShowEnvironmentAndFolders.html
@@ -24,7 +24,7 @@
 	</div>
 </form>
 <form class="t3js-installer-environmentFolders-good" style="display: none;">
-	<button class="btn success t3js-installer-environmentFolders-execute">
+	<button class="btn btn-success t3js-installer-environmentFolders-execute">
 		System looks good. Continue!
 	</button>
 </form>


### PR DESCRIPTION
The "success" class on line 27 was missing the "btn-" prefix.