### PR TITLE
file name needlessly escaped

### DIFF
--- a/typo3/sysext/scheduler/Documentation/DevelopersGuide/CreatingTasks/Index.rst
+++ b/typo3/sysext/scheduler/Documentation/DevelopersGuide/CreatingTasks/Index.rst
@@ -268,7 +268,7 @@ Declaring the task class
 
 As a last step, the task class must be declared so the Scheduler knows
 of its existence. The declaration must be placed in the
-:code:`ext\_localconf.php` file of the extension that provides the
+:code:`ext_localconf.php` file of the extension that provides the
 task. Let's look at one of the base classes declaration as an example:
 
 ::


### PR DESCRIPTION
ext_localconf.php is displayed as ext\_localconf.php on the official page;
https://docs.typo3.org/typo3cms/extensions/scheduler/latest/DevelopersGuide/CreatingTasks/Index.html#declaring-the-task-class