### PR TITLE
get original resource in the correct language

### DIFF
--- a/typo3/sysext/extbase/Classes/Domain/Model/FileReference.php
+++ b/typo3/sysext/extbase/Classes/Domain/Model/FileReference.php
@@ -44,7 +44,7 @@ class FileReference extends \TYPO3\CMS\Extbase\Domain\Model\AbstractFileFolder
     public function getOriginalResource()
     {
         if ($this->originalResource === null) {
-            $this->originalResource = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance()->getFileReferenceObject($this->getUid());
+            $this->originalResource = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance()->getFileReferenceObject($this->_localizedUid);
         }
 
         return $this->originalResource;


### PR DESCRIPTION
The kid of an extbase object is always the id of the default language.
However, file references may contain translations like other titles/descriptions.

Previous behavior: The original resource was always in the default language and therefor unusable.
Expected/Now behavior: The original resource requested in the translated language.

I have tested this in typo3 8.7.