### PR TITLE
Fix for Backend not scrollable

### DIFF
--- a/typo3/sysext/backend/Resources/Private/Templates/Backend/Main.html
+++ b/typo3/sysext/backend/Resources/Private/Templates/Backend/Main.html
@@ -14,7 +14,7 @@
 			</div>
 		</div>
 		<div class="scaffold-content-module t3js-scaffold-content-module">
-			<iframe name="list_frame" id="typo3-contentIframe" scrolling="no" class="scaffold-content-module-iframe t3js-scaffold-content-module-iframe"></iframe>
+			<iframe name="list_frame" id="typo3-contentIframe" scrolling="yes" class="scaffold-content-module-iframe t3js-scaffold-content-module-iframe"></iframe>
 		</div>
 		<div class="scaffold-content-overlay t3js-scaffold-content-overlay"></div>
 	</div>


### PR DESCRIPTION
Some Extensions are not scrollabe any more since the iframe #typo3-contentIframe has added a scrolling="no"