### PR TITLE
Update MediaViewHelper.php

### DIFF
--- a/typo3/sysext/fluid/Classes/ViewHelpers/MediaViewHelper.php
+++ b/typo3/sysext/fluid/Classes/ViewHelpers/MediaViewHelper.php
@@ -83,6 +83,7 @@ class MediaViewHelper extends AbstractTagBasedViewHelper
     public function render()
     {
         $file = $this->arguments['file'];
+        $additionalAttributes = $this->arguments['additionalAttributes'];        
         $additionalConfig = $this->arguments['additionalConfig'];
         $width = $this->arguments['width'];
         $height = $this->arguments['height'];
@@ -103,8 +104,9 @@ class MediaViewHelper extends AbstractTagBasedViewHelper
         if ($fileRenderer === null) {
             return $this->renderImage($file, $width, $height);
         }
+        $additionalAttributes = array_merge_recursive($this->arguments, $additionalAttributes);
         $additionalConfig = array_merge_recursive($this->arguments, $additionalConfig);
-        return $fileRenderer->render($file, $width, $height, $additionalConfig);
+        return $fileRenderer->render($file, $width, $height, $additionalAttributes, $additionalConfig);
     }
 
     /**


### PR DESCRIPTION
Allow additionalAttributes in function render
In some cases, it is useful to call the Render-Fuction with additionalAttributes from your fluid-Template (e.g. by providing a poster-Attribut with a video-Tag like <f:media additionalAttributes="{poster: 'fallback-img.jpg'}" ) 
Alltough this additionalAttributes ist already registered by the Core at this position, the function render() did not made use of it so far.