### PR TITLE
fix btn-group implementation

### DIFF
--- a/typo3/sysext/form/Resources/Private/Frontend/Partials/Form/Navigation.html
+++ b/typo3/sysext/form/Resources/Private/Frontend/Partials/Form/Navigation.html
@@ -3,19 +3,19 @@
 	<div class="btn-toolbar" role="toolbar">
 		<div class="btn-group" role="group">
 			<f:if condition="{form.previousPage}">
-				<span class="previous">
+				<span class="btn-group previous">
 					<f:form.hidden property="__currentPage" value="{form.previousPage.index}" />
 					<f:form.button type="button" onclick="document.forms['{form.formDefinition.identifier}'].submit();" class="btn btn-cancel" formnovalidate="formnovalidate">{formvh:translateElementProperty(element: form.currentPage, renderingOptionProperty: 'previousButtonLabel')}</f:form.button>
 				</span>
 			</f:if>
 			<f:if condition="{form.nextPage}">
 				<f:then>
-					<span class="next">
+					<span class="btn-group next">
 						<f:form.button property="__currentPage" value="{form.nextPage.index}" class="btn btn-primary">{formvh:translateElementProperty(element: form.currentPage, renderingOptionProperty: 'nextButtonLabel')}</f:form.button>
 					</span>
 				</f:then>
 				<f:else>
-					<span class="next submit">
+					<span class="btn-group next submit">
 						<f:form.button property="__currentPage" value="{form.pages -> f:count()}" class="btn btn-primary">
 							{formvh:translateElementProperty(element: form, renderingOptionProperty: 'submitButtonLabel')}
 						</f:form.button>


### PR DESCRIPTION
The current btn-group implementation using spans results in :first-child and :last-child not working correctly.
There is actually a workaround implemented in bootstrap itself which is also necessary for using btn-group-justified.
Just add btn-group inside the btn-group.