### PR TITLE
BUGFIX: PHP 7.1 Reflection error for default value

### DIFF
--- a/typo3/sysext/extbase/Classes/Object/Container/ClassInfoFactory.php
+++ b/typo3/sysext/extbase/Classes/Object/Container/ClassInfoFactory.php
@@ -65,9 +65,8 @@ class ClassInfoFactory
                 $info['dependency'] = $reflectionParameter->getClass()->getName();
             }
 
-            try {
+            if ($reflectionParameter->isDefaultValueAvailable()) {
                 $info['defaultValue'] = $reflectionParameter->getDefaultValue();
-            } catch (\ReflectionException $e) {
             }
 
             $result[] = $info;


### PR DESCRIPTION
In PHP 7.1 under some circumstances the exception is not caught
as expected.
Therefore we use a check, as already done in ReflectionService.php