### PR TITLE
Related to #32030 change from search to settings

### DIFF
--- a/typo3/sysext/indexed_search/Documentation/Configuration/TypoScript/Index.rst
+++ b/typo3/sysext/indexed_search/Documentation/Configuration/TypoScript/Index.rst
@@ -237,15 +237,15 @@ search.defaultFreeIndexUidList
 
 
 
-.. _search-exactcount:
+.. _settings-exactcount:
 
-search.exactCount
+settings.exactCount
 """""""""""""""""
 
 .. container:: table-row
 
    Property
-         search.exactCount
+         settings.exactCount
 
    Data type
          boolean


### PR DESCRIPTION
https://forge.typo3.org/issues/32030

search.exactCount is wrong. Has to be settings.exactCount