### PR TITLE
[BUGFIX] Correctly instantiate FE users "image"-property as ObjectSto…

### DIFF
--- a/typo3/sysext/extbase/Classes/Domain/Model/FrontendUser.php
+++ b/typo3/sysext/extbase/Classes/Domain/Model/FrontendUser.php
@@ -133,6 +133,7 @@ class FrontendUser extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         $this->username = $username;
         $this->password = $password;
         $this->usergroup = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $this->image = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
     }
 
     /**


### PR DESCRIPTION
…rage

Reason: If another object is accessing the property and expects an ObjectStorage, then functions like foreach will cause an error if the property is NULL.