### PR TITLE
stuck in infinite loop when deleting a file

### DIFF
--- a/typo3/sysext/core/Classes/Resource/ResourceStorage.php
+++ b/typo3/sysext/core/Classes/Resource/ResourceStorage.php
@@ -3064,6 +3064,7 @@ class ResourceStorage implements ResourceStorageInterface
 
         $recyclerFolder = null;
         $folder = $file->getParentFolder();
+        $rootFolder = $this->getRootLevelFolder(false);
 
         do {
             if ($folder->getRole() === FolderInterface::ROLE_RECYCLER) {
@@ -3078,7 +3079,7 @@ class ResourceStorage implements ResourceStorageInterface
             }
 
             $parentFolder = $folder->getParentFolder();
-            $isFolderLoop = $folder->getIdentifier() === $parentFolder->getIdentifier();
+            $isFolderLoop = $folder->getIdentifier() === $rootFolder->getIdentifier();
             $folder = $parentFolder;
         } while ($recyclerFolder === null && !$isFolderLoop);
 


### PR DESCRIPTION
i use a S3 FAL Driver and it gets stuck in this infinite loop when trying to delete a file. i posted a issue there, https://github.com/andersundsehr/aus_driver_amazon_s3/issues/36

but now i think its this error here, i noticed the error when updating from 8.7.15 to 8.7.16 and should also be here in master.

line 3082: to me it doesnt make ANY sense that the identifier of the parent is the same as the folder itself thus, the do while loop never exits. i hope my PR is the fix and doesnt break anything. it looks fine for me in 8.7.16

i also think its bad practice to use do while loops because its very easy to make a mistake and get stuck in the loop and also i found this very hard to understand and so it took me quite a while to understand this code, especially the isFolderLoop condition.