### PR TITLE
[FEATURE] Allow specifying a CURL_IPRESOLVE variant for cURL requests.

### DIFF
--- a/typo3/sysext/core/Classes/Utility/GeneralUtility.php
+++ b/typo3/sysext/core/Classes/Utility/GeneralUtility.php
@@ -2505,6 +2505,9 @@ class GeneralUtility
                     curl_setopt($ch, CURLOPT_PROXYUSERPWD, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']);
                 }
             }
+            if (in_array((int)$GLOBALS['TYPO3_CONF_VARS']['SYS']['curlIpResolve'], array(CURL_IPRESOLVE_V4, CURL_IPRESOLVE_V6)) ) {
+                curl_setopt($ch, CURLOPT_IPRESOLVE, (int)$GLOBALS['TYPO3_CONF_VARS']['SYS']['curlIpResolve']);
+            }
             $content = curl_exec($ch);
             $curlInfo = curl_getinfo($ch);
 

--- a/typo3/sysext/core/Configuration/DefaultConfiguration.php
+++ b/typo3/sysext/core/Configuration/DefaultConfiguration.php
@@ -88,6 +88,7 @@ return [
          * @deprecated since 4.6 - will be removed in 6.2.
          */
         'curlTimeout' => 0,                        // Integer: Timeout value for cURL requests in seconds. 0 means to wait indefinitely. Deprecated since 4.6 - will be removed in 6.2. See below for http options.
+        'curlIpResolve' => CURL_IPRESOLVE_WHATEVER,    // <p>Integer (0, 1, 2). Specifies which IP protocol version to use for cURL requests</p><dl><dt>0</dt><dd>resolves addresses to all IP versions that your system allows</dd><dt>1</dt><dd>Resolve to IPv4 addresses</dd><dt>2</dt><dd>Resolve to IPv6 addresses</dd></dl>
         'textfile_ext' => 'txt,ts,typoscript,html,htm,css,tmpl,js,sql,xml,csv,xlf',    // Text file extensions. Those that can be edited. Executable PHP files may not be editable in webspace if disallowed!
         'mediafile_ext' => 'gif,jpg,jpeg,bmp,png,pdf,svg,ai,mp3,wav,mp4,webm,youtube,vimeo',    // Commalist of file extensions perceived as media files by TYPO3. Lowercase and no spaces between!
         'binPath' => '',                        // String: List of absolute paths where external programs should be searched for. Eg. <code>/usr/local/webbin/,/home/xyz/bin/</code>. (ImageMagick path have to be configured separately)


### PR DESCRIPTION
This allows specifying an IP resolve method for cURL requests in `GeneralUtility::getUrl`.

That change can prevent weird issues with certain SSL/TLS certificates where this function fails although when specifying the correct [CURL_IPRESOLVE](http://php.net/manual/en/function.curl-setopt.php) type, it does indeed work.

This should also be - and also can - backported to the TYPO3 v6.2 branch.