### PR TITLE
Add "datetimesec" eval option for type="input" renderType="inputDateTime"

### DIFF
--- a/typo3/sysext/backend/Classes/Form/Element/AbstractFormElement.php
+++ b/typo3/sysext/backend/Classes/Form/Element/AbstractFormElement.php
@@ -223,6 +223,12 @@ abstract class AbstractFormElement extends AbstractNode
                     $itemValue = BackendUtility::datetime((int)$itemValue);
                 }
                 break;
+            case 'datetimesec':
+                // compatibility with "eval" (type "input")
+                if ($itemValue !== '' && !is_null($itemValue)) {
+                    $itemValue = BackendUtility::datetimesec((int)$itemValue);
+                }
+                break;
             case 'time':
                 // compatibility with "eval" (type "input")
                 if ($itemValue !== '' && $itemValue !== null) {

--- a/typo3/sysext/backend/Classes/Form/Element/InputDateTimeElement.php
+++ b/typo3/sysext/backend/Classes/Form/Element/InputDateTimeElement.php
@@ -76,6 +76,9 @@ class InputDateTimeElement extends AbstractFormElement
         } elseif (in_array('datetime', $evalList, true)) {
             $format = 'datetime';
             $defaultInputWidth = 13;
+        } elseif (in_array('datetimesec', $evalList, true)) {
+            $format = 'datetimesec';
+            $defaultInputWidth = 16;
         } elseif (in_array('time', $evalList, true)) {
             $format = 'time';
         } elseif (in_array('timesec', $evalList, true)) {
@@ -83,7 +86,7 @@ class InputDateTimeElement extends AbstractFormElement
         } else {
             throw new \RuntimeException(
                 'Field "' . $fieldName . '" in table "' . $table . '" with renderType "inputDataTime" needs'
-                . '"eval" set to either "date", "datetime", "time" or "timesec"',
+                . '"eval" set to either "date", "datetime", "datetimesec", "time" or "timesec"',
                 1483823746
             );
         }

--- a/typo3/sysext/backend/Classes/Utility/BackendUtility.php
+++ b/typo3/sysext/backend/Classes/Utility/BackendUtility.php
@@ -1163,6 +1163,20 @@ class BackendUtility
             $value
         );
     }
+    
+    /**
+     * Returns $tstamp formatted as "ddmmyy hhmmss" (According to $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] AND $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm']) + ":s"
+     *
+     * @param int $value Time stamp, seconds
+     * @return string Formatted time
+     */
+    public static function datetimesec($value)
+    {
+        return date(
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] . ' ' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'] . ':s',
+            $value
+        );
+    }
 
     /**
      * Returns $value (in seconds) formatted as hh:mm:ss
@@ -2246,6 +2260,16 @@ class BackendUtility
                         }
                         if (!empty($value)) {
                             $l = self::datetime($value);
+                        }
+                    } elseif (GeneralUtility::inList($theColConf['eval'] ?? '', 'datetimesec')) {
+                        // Handle native datetime field
+                        if (isset($theColConf['dbType']) && $theColConf['dbType'] === 'datetime') {
+                            $value = $value === $dateTimeFormats['datetime']['empty'] ? 0 : (int)strtotime($value);
+                        } else {
+                            $value = (int)$value;
+                        }
+                        if (!empty($value)) {
+                            $l = self::datetimesec($value);
                         }
                     } else {
                         $l = $value;


### PR DESCRIPTION
People (like me for example) may like to have full time including seconds in Backend for specific input-fields, e.g. in custom log-singletons/domain-models, without setting $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'] to 'h:i:s' generally.