### PR TITLE
Add remark about [TYPO3_CONF_VARS][FE][loginSecurityLevel] to Deprecation of EXT:rsaauth

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/9.1/Deprecation-81852-DeprecatedUsageOfEXTrsaauth.rst
+++ b/typo3/sysext/core/Documentation/Changelog/9.1/Deprecation-81852-DeprecatedUsageOfEXTrsaauth.rst
@@ -41,4 +41,6 @@ Use https:// for any site, especially for pages which transfer passwords, includ
 The usage of a secure connection is also enforced by the browsers which mark http:// pages that
 collect passwords or credit cards as insecure. In long-term all http:// sites will be marked as insecure.
 
+If you deactivate EXT:rsaauth, remember to also set [TYPO3_CONF_VARS][BE][loginSecurityLevel] and [TYPO3_CONF_VARS][FE][loginSecurityLevel] from 'rsa' to 'normal'. 
+
 .. index:: Backend, Frontend, NotScanned


### PR DESCRIPTION
I had a typo3 8.7 website with EXT:rsaauth active. A common problem with that is, that Users cannot login when using very long passwords. https://forge.typo3.org/issues/85321 The recommended approach is to deactivate ext:rsaauth (as long as using https at the same time). I tried that out, but could not login anymore with my old password. I then found out that at the same time and you need to set loginSecurityLevel to 'normal'. for FE and BE. So I think it makes sense to mention it here.