### PR TITLE
[BUGFIX] Fix exception in IconFactory with deleted link record 

### DIFF
--- a/typo3/sysext/backend/Classes/Form/Element/InputLinkElement.php
+++ b/typo3/sysext/backend/Classes/Form/Element/InputLinkElement.php
@@ -404,7 +404,7 @@ class InputLinkElement extends AbstractFormElement
                 break;
             case LinkService::TYPE_RECORD:
                 $table = $this->data['pageTsConfig']['TCEMAIN.']['linkHandler.'][$linkData['identifier'] . '.']['configuration.']['table'];
-                $record = BackendUtility::getRecord($table, $linkData['uid']);
+                $record = BackendUtility::getRecord($table, $linkData['uid'],'*','',false);
                 if ($record) {
                     $recordTitle = BackendUtility::getRecordTitle($table, $record);
                     $tableTitle = $this->getLanguageService()->sL($GLOBALS['TCA'][$table]['ctrl']['title']);

--- a/typo3/sysext/core/Configuration/DefaultConfiguration.php
+++ b/typo3/sysext/core/Configuration/DefaultConfiguration.php
@@ -263,6 +263,7 @@ return [
             ],
             'overlayPriorities' => [
                 'hidden',
+                'deleted',
                 'starttime',
                 'endtime',
                 'futureendtime',


### PR DESCRIPTION
When a record link is deleted, the InputLinkElement was not checked if the
link had actually been deleted, and from that bug I could see that the
icon overlay did not even exist in DefaultConfiguration.