### PR TITLE
Adding 3 to "TYPO"

### DIFF
--- a/typo3/sysext/core/Resources/Private/Language/locallang_csh_sysfilestorage.xlf
+++ b/typo3/sysext/core/Resources/Private/Language/locallang_csh_sysfilestorage.xlf
@@ -19,7 +19,7 @@
 				<source>The visible identifier for this file storage.</source>
 			</trans-unit>
 			<trans-unit id="name.details">
-				<source>The label entered here will be shown as the name for the entry point in the TYPO Backend. Be sure to make it descriptive and logical for your editors.</source>
+				<source>The label entered here will be shown as the name for the entry point in the TYPO3 Backend. Be sure to make it descriptive and logical for your editors.</source>
 			</trans-unit>
 			<trans-unit id="description.description">
 				<source>A description of this storage.</source>


### PR DESCRIPTION
On other "TYPO3" reference the "3" is present but not on this occurence. So i added the "3" to "TYPO" in order to have "TYPO3".