### PR TITLE
[FEATURE] Render the copyright with a allowLanguageSynchronization

### DIFF
--- a/typo3/sysext/filemetadata/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/typo3/sysext/filemetadata/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -260,11 +260,15 @@ $tca = [
         ],
         'copyright' => [
             'exclude' => true,
+            'l10n_display' => '',
             'label' => 'LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:sys_file_metadata.copyright',
             'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 3,
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
             ],
         ],
         'location_country' => [


### PR DESCRIPTION
Don't really see the difference between the copyright and the location_city in the localization handling.

Example:
City:
Genève => Genf
Lausanne
Copyright:
Jean => Hans
Daniel