### PR TITLE
Little FIX for ArrayUtility.php

### DIFF
--- a/typo3/sysext/core/Classes/Utility/ArrayUtility.php
+++ b/typo3/sysext/core/Classes/Utility/ArrayUtility.php
@@ -235,7 +235,7 @@ class ArrayUtility
         foreach ($result as $key => $value) {
             if (is_array($value)) {
                 $result[$key] = self::removeNullValuesRecursive($value);
-            } elseif ($value === null) {
+            } elseif ($value == null) {
                 unset($result[$key]);
             }
         }


### PR DESCRIPTION
Hi, i think its better to use '==' instead of '===', in this case will also match "",[],0... So i think its bettre option to remove empty stuff from array. What you think?