### PR TITLE
Add another example of field types

### DIFF
--- a/typo3/sysext/form/Documentation/Concepts/FormConfigurationFormDefinition/Index.rst
+++ b/typo3/sysext/form/Documentation/Concepts/FormConfigurationFormDefinition/Index.rst
@@ -103,7 +103,10 @@ Example form definition
            validators:
              -
                identifier: NotEmpty
-
+         -
+           identifier: hidden
+           label: 'Hidden Field'
+           type: Hidden
      -
        identifier: summarypage
        label: 'Summary page'


### PR DESCRIPTION
How to add hidden fields to one's form is quite hard to get from the documentation in my opinion. With a hidden field in the example form definition it's maybe easier to get the gist on how to add a hidden field.