### PR TITLE
Fix Regex Pattern

### DIFF
--- a/typo3/sysext/backend/Resources/Public/JavaScript/FormEngine.js
+++ b/typo3/sysext/backend/Resources/Public/JavaScript/FormEngine.js
@@ -192,7 +192,7 @@ define(['jquery',
       // The incoming value consists of the table name, an underscore and the uid
       // or just the uid
       // For a single selection field we need only the uid, so we extract it
-      var pattern = /_(\\d+)$/
+      var pattern = /_(\d+)$/
         , result = value.toString().match(pattern);
 
       if (result != null) {


### PR DESCRIPTION
Here is a test for this pattern:

```js
var value= 'pages_3456'
,pattern = /_(\d+)$/
,result = value.toString().match(pattern);
console.log(result);
```

it only works if the pattern is `/_(\d+)$/` if it has the additional `\` it dose not remove the table name.