### PR TITLE
Fix minor syntax

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/9.4/Feature-85829-ImplementSymfonyExpressionLanguageForTypoScriptConditions.rst
+++ b/typo3/sysext/core/Documentation/Changelog/9.4/Feature-85829-ImplementSymfonyExpressionLanguageForTypoScriptConditions.rst
@@ -206,7 +206,7 @@ the most core functions.
 Please read .. _the introduction: https://docs.typo3.org/typo3cms/extensions/core/Changelog/9.4/Feature-85828-MoveSymfonyExpressionLanguageHandlingIntoEXTcore.html first.
 
 Add new methods by implementing own providers which implement the :php:`ExpressionFunctionProviderInterface` and
-register the provider for the key `typoscript` in your own :file:`Configuration\ExpressionLanguage.php` file:
+register the provider for the key `typoscript` in your own :file:`Configuration/ExpressionLanguage.php` file:
 
 .. code-block:: php
 


### PR DESCRIPTION
Change backslash to slash in file format, where backslash is not visible in rendered HTML - it is a file path, not a PHP namespace.