### PR TITLE
Update ConnectionPool.php

### DIFF
--- a/typo3/sysext/core/Classes/Database/ConnectionPool.php
+++ b/typo3/sysext/core/Classes/Database/ConnectionPool.php
@@ -145,7 +145,7 @@ class ConnectionPool
 
         // Force consistent handling of binary objects across datbase platforms
         // MySQL returns strings by default, PostgreSQL streams.
-        if (strpos($connectionParams['driver'], 'pdo_') === 0) {
+        if ($connectionParams['driver'] !== 'pdo_mysql' && strpos($connectionParams['driver'], 'pdo_') === 0) {
             $connectionParams['driverOptions'][\PDO::ATTR_STRINGIFY_FETCHES] = true;
         }
 


### PR DESCRIPTION
I would like to get int and floats from my MySQL server. 
For that I must set
````php
$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
$pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
````

This patch allows to set ATTR_STRINGIFY_FETCHES for pdo_mysql again.

see: https://stackoverflow.com/questions/1197005/how-to-get-numeric-types-from-mysql-using-pdo/15592818#15592818