### PR TITLE
Missing quote in declaring the task example

### DIFF
--- a/typo3/sysext/scheduler/Documentation/DevelopersGuide/CreatingTasks/Index.rst
+++ b/typo3/sysext/scheduler/Documentation/DevelopersGuide/CreatingTasks/Index.rst
@@ -275,7 +275,7 @@ task. Let's look at one of the base classes declaration as an example:
 
 	// Add caching framework garbage collection task
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\TYPO3\CMS\Scheduler\Task\CachingFrameworkGarbageCollectionTask::class] = array(
-		'extension' => 'your_extension_key,
+		'extension' => 'your_extension_key',
 		'title' => 'LLL:EXT:your_extension_key/locallang.xlf:cachingFrameworkGarbageCollection.name',
 		'description' => 'LLL:EXT:your_extension_key/locallang.xlf:cachingFrameworkGarbageCollection.description',
 		'additionalFields' => \TYPO3\CMS\Scheduler\Task\CachingFrameworkGarbageCollectionAdditionalFieldProvider::class


### PR DESCRIPTION
The current declaring a task example produces a PHP syntax error because of a missing quote