### PR TITLE
Fix scroll behaviour of "Uncaught Exceptions" in backend

### DIFF
--- a/typo3/sysext/core/Classes/Error/DebugExceptionHandler.php
+++ b/typo3/sysext/core/Classes/Error/DebugExceptionHandler.php
@@ -91,6 +91,9 @@ class DebugExceptionHandler extends AbstractExceptionHandler
 							font-size: 12px;
 							margin: 10px;
 							padding: 0;
+                            right: 10px;
+                            overflow: scroll;
+                            max-height: calc(100% - 24px);
 						">
 						<div style="width: 100%; background-color: #515151; color: white; padding: 2px; margin: 0 0 6px 0;">Uncaught TYPO3 Exception</div>
 						<div style="width: 100%; padding: 2px; margin: 0 0 6px 0;">


### PR DESCRIPTION
In the TYPO3 Backend of version 8, the iframe page (id "typo3-contentIframe") is not scrollable, when an "uncaught exception" is thrown and its content exceeds the page. The simplest way to fix this behavior seems to be by adding 3 CSS rules to the very first div element after the body tag in the iframe page (right, max-height and overflow; "right" is needed to enable horizontal scrolling).

This solution is not perfect, when it comes to horizontal scrolling - but better than the current situation.