### PR TITLE
[BUGFIX] FileWriter JSON output

### DIFF
--- a/typo3/sysext/core/Classes/Log/Writer/FileWriter.php
+++ b/typo3/sysext/core/Classes/Log/Writer/FileWriter.php
@@ -154,7 +154,7 @@ class FileWriter extends AbstractWriter
             if (isset($recordData['exception']) && $recordData['exception'] instanceof \Exception) {
                 $recordData['exception'] = (string)$recordData['exception'];
             }
-            $data = '- ' . json_encode($recordData);
+            $data = '- ' . json_encode($recordData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
         }
 
         $message = sprintf(


### PR DESCRIPTION
Since PHP 5.4 it's possible to disable escaping for unicode characters and slashes, which results in a much cleaner, leaner and most importantly readable TYPO3 log output.

Related: #77274