### PR TITLE
Added missing fe_login hooks

### DIFF
--- a/typo3/sysext/felogin/Documentation/Hooks/Index.rst
+++ b/typo3/sysext/felogin/Documentation/Hooks/Index.rst
@@ -24,9 +24,11 @@ $GLOBALS['TYPO3\_CONF\_VARS']['EXTCONF']['felogin']['postProcContent']
 $GLOBALS['TYPO3\_CONF\_VARS']['EXTCONF']['felogin']['login\_confirmed']
   Hook for general actions after login has been confirmed
 
+$GLOBALS['TYPO3\_CONF\_VARS']['EXTCONF']['felogin']['login\_error']
+  Hook for general actions on login error
+
 $GLOBALS['TYPO3\_CONF\_VARS']['EXTCONF']['felogin']['loginFormOnSubmitFuncs']
-  This Hook is used by kb\_md5fepw extension to set hidden
-  fields and onsubmit-scripts
+  This hook can be used to set hidden fields and onsubmit-scripts
 
 $GLOBALS['TYPO3\_CONF\_VARS']['EXTCONF']['felogin']['logout\_confirmed']
   Hook for general actions after logout has been confirmed
@@ -34,3 +36,6 @@ $GLOBALS['TYPO3\_CONF\_VARS']['EXTCONF']['felogin']['logout\_confirmed']
 $GLOBALS['TYPO3\_CONF\_VARS']['EXTCONF']['felogin']['forgotPasswordMail ']
   Hook to change the contents of the forgot password mail
 
+$GLOBALS['TYPO3\_CONF\_VARS']['EXTCONF']['felogin']['password\_changed']
+  Receives an array containing the user and the newPassword, allows to mark the
+  password as invalid using 'passwordValid' and set a 'passwordInvalidMessage'


### PR DESCRIPTION
Adds the missing documentation of the hooks
* `login_error` added in TYPO3 6.0 
https://review.typo3.org/c/Packages/TYPO3.CMS/+/6600 
* `password_changed` added in TYPO3 4.3
https://github.com/TYPO3/TYPO3.CMS/commit/39441104649280393f3c54a5bb33b67be294f41a