### PR TITLE
Added missed initialization of DataMapper on QueryResult object wakeup

### DIFF
--- a/typo3/sysext/extbase/Classes/Persistence/Generic/QueryResult.php
+++ b/typo3/sysext/extbase/Classes/Persistence/Generic/QueryResult.php
@@ -264,6 +264,7 @@ class QueryResult implements QueryResultInterface
     {
         $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Object\ObjectManager::class);
         $this->persistenceManager = $objectManager->get(\TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface::class);
+        $this->dataMapper = $objectManager->get(DataMapper::class);
     }
 
     /**


### PR DESCRIPTION
`DataMapper` object initialization is missed in this place.
And it leads to error `Call to a member function map() on null` when `QueryResult` object retrieved from cache.