### PR TITLE
[FEATURE] Add index to slug field

### DIFF
--- a/typo3/sysext/core/ext_tables.sql
+++ b/typo3/sysext/core/ext_tables.sql
@@ -115,7 +115,8 @@ CREATE TABLE pages (
 	legacy_overlay_uid int(11) unsigned DEFAULT '0' NOT NULL,
 
 	KEY determineSiteRoot (is_siteroot),
-	KEY language_identifier (l10n_parent,sys_language_uid)
+	KEY language_identifier (l10n_parent,sys_language_uid),
+	KEY slug(slug)
 );
 
 #


### PR DESCRIPTION
`TYPO3\CMS\Core\Routing\PageRouter::getPagesFromDatabaseForCandidates` looks-up candidates for the page using the `slug` field (and also sorts by this value). This has some serious impact on the website performance on systems with lots of pages. In order to optimize this, an index should be set.