### PR TITLE
[BUGFIX] Fix AnnotationException

### DIFF
--- a/typo3/sysext/core/Classes/Utility/GeneralUtility.php
+++ b/typo3/sysext/core/Classes/Utility/GeneralUtility.php
@@ -2107,7 +2107,7 @@ class GeneralUtility
      *
      * @param string $path Absolute path to folder, see PHP rmdir() function. Removes trailing slash internally.
      * @param bool $removeNonEmpty Allow deletion of non-empty directories
-     * @return bool TRUE if @rmdir went well!
+     * @return bool TRUE if {@rmdir} went well!
      */
     public static function rmdir($path, $removeNonEmpty = false)
     {


### PR DESCRIPTION
Doctrine\Common\Annotations\AnnotationException
[Semantical Error] The annotation "@mkdir" in method TYPO3\CMS\Core\Utility\GeneralUtility::mkdir() was never imported. Did you maybe forget to add a "use" statement for this annotation?