### PR TITLE
[TASK] Remove unused Fieldset property in documentaion of EXT:form

### DIFF
--- a/typo3/sysext/form/Documentation/I/Config/proto/formElements/formElementTypes/Fieldset.rst
+++ b/typo3/sysext/form/Documentation/I/Config/proto/formElements/formElementTypes/Fieldset.rst
@@ -15,9 +15,6 @@ Properties
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fieldset.implementationclassname:
 .. include:: Fieldset/implementationClassName.rst
 
-.. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fieldset.properties.containerclassattribute:
-.. include:: Fieldset/properties/containerClassAttribute.rst
-
 .. _typo3.cms.form.prototypes.<prototypeIdentifier>.formelementsdefinition.fieldset.properties.elementclassattribute:
 .. include:: Fieldset/properties/elementClassAttribute.rst
 


### PR DESCRIPTION
The "containerClassAttribute" property is not respected by elements of
type "Fieldset" as the partial "Field/Field" takes care of its
rendering. Therefore it has been removed from the official documentation
to avoid confusions.

Releases: master, 9.5, 8.7