### PR TITLE
Change .yml to .yaml

### DIFF
--- a/typo3/sysext/form/Documentation/I/Concepts/Finishers/Index.rst
+++ b/typo3/sysext/form/Documentation/I/Concepts/Finishers/Index.rst
@@ -437,5 +437,5 @@ Make sure the setup file is registered in the backend:
 .. code-block:: typoscript
 
    module.tx_form.settings.yamlConfigurations {
-      123456789 = EXT:yourExtension/Configuration/Form/Backend.yml
+      123456789 = EXT:yourExtension/Configuration/Form/Backend.yaml
    }


### PR DESCRIPTION
It may be a little petty, but to avoid confusing users, we should use a uniform extension for the YAML files in the documentation.