### PR TITLE
Text wrong or code wrong

### DIFF
--- a/typo3/sysext/fluid_styled_content/Documentation/AddingYourOwnContentElements/Index.rst
+++ b/typo3/sysext/fluid_styled_content/Documentation/AddingYourOwnContentElements/Index.rst
@@ -158,7 +158,7 @@ Now you can register the rendering of your custom content element using a Fluid 
 .. code-block:: typoscript
 
    tt_content {
-       yourextensionkey_newcontentelement =< lib.contentElement
+       yourextensionkey_newcontentelement < lib.contentElement
        yourextensionkey_newcontentelement {
            templateName = NewContentElement
        }


### PR DESCRIPTION
The example code uses an object reference operator and the text says that the object will be copied.
Two possibilities:
1. Change operator (what i did)
2. Change text to 'references'
Both will work but copy would have less side effects.