### PR TITLE
Remove confusing “cron command” ambiguity.

### DIFF
--- a/typo3/sysext/scheduler/Documentation/Administration/EditTask/Index.rst
+++ b/typo3/sysext/scheduler/Documentation/Administration/EditTask/Index.rst
@@ -40,10 +40,12 @@ available by moving the mouse over the field labels):
   bottom of the form.
 
 - The frequency needs be entered only for recurring tasks. It can be
-  either a number of seconds or a cron-like command. Since TYPO3 4.5 the
-  Scheduler supports the full cron syntax, including ranges, steps and
-  keywords like :code:`@weekly` . For more information on cron syntax,
-  see http://en.wikipedia.org/wiki/CRON\_expression.
+  either an integer number of seconds or a cron-like schedule expression. 
+  Scheduler supports ranges, steps and keywords like :code:`@weekly` .  
+  See https://en.wikipedia.org/wiki/Cron#CRON_expression for more 
+  information. See TYPO3\\CMS\\Scheduler\\CronCommand\\CronCommand and 
+  TYPO3\\CMS\\Scheduler\\CronCommand\\NormalizeCommand class references 
+  in the TYPO3 CMS source code for definitive rules.
 
 - Parallel executions are denied by default (see "Tasks execution"
   above). They must be allowed explicitly.


### PR DESCRIPTION
Remove the ambiguity of “cron command” that causes confusion for a first time reader, as happened in https://forge.typo3.org/issues/75802 . Saying “cron command” implies the entire instruction, including the shell command portion. Instead, we want only the patterns of the first five fields of a crontab entry input file line, described in “The Open Group Base Specifications Issue 7, 2018 edition” at https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html . There is no definitive name for these five fields as a group: “cron schedule expression” or “crontab schedule expression” are descriptive.