### PR TITLE
Update hostHeaderValueMatchesTrustedHostsPattern

### DIFF
--- a/typo3/sysext/core/Classes/Utility/GeneralUtility.php
+++ b/typo3/sysext/core/Classes/Utility/GeneralUtility.php
@@ -2947,7 +2947,9 @@ class GeneralUtility
             // Note that this is only secure if name base virtual host are configured correctly in the webserver
             $defaultPort = self::getIndpEnv('TYPO3_SSL') ? '443' : '80';
             $parsedHostValue = parse_url('http://' . $hostHeaderValue);
-            if (isset($parsedHostValue['port'])) {
+            if (self::getIndpEnv('TYPO3_REV_PROXY') && isset($parsedHostValue['port'])) {
+                $hostMatch = (strtolower($parsedHostValue['host']) === strtolower($_SERVER['SERVER_NAME']) && (string)$parsedHostValue['port'] === $defaultPort);
+            } elseif (isset($parsedHostValue['port'])) {
                 $hostMatch = (strtolower($parsedHostValue['host']) === strtolower($_SERVER['SERVER_NAME']) && (string)$parsedHostValue['port'] === $_SERVER['SERVER_PORT']);
             } else {
                 $hostMatch = (strtolower($hostHeaderValue) === strtolower($_SERVER['SERVER_NAME']) && $defaultPort === $_SERVER['SERVER_PORT']);


### PR DESCRIPTION
If we are behind a reverse proxy (that uses http connection to TYPO3 and https to the client) and host header value includes port then check if:

$parsedHostValue['host'] equals strtolower($_SERVER['SERVER_NAME'])
and
(string)$parsedHostValue['port'] equals $defaultPort.

Otherwise SERVER_PORT equals Port 80 and parsedHostValue['port'] is reporting NULL (or 443 when included in the header) and the check always fails =>
- (string)$parsedHostValue['port']: 443 != $_SERVER['SERVER_PORT']: 80
- $defaultPort: 443 != $_SERVER['SERVER_PORT']: 80

My code might be utter trash so please check if it is secure.