### PR TITLE
[BUGFIX] Only last postProcContent-hook is applied

### DIFF
--- a/typo3/sysext/felogin/Classes/Controller/FrontendLoginController.php
+++ b/typo3/sysext/felogin/Classes/Controller/FrontendLoginController.php
@@ -207,6 +207,7 @@ class FrontendLoginController extends AbstractPlugin
         ];
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['postProcContent'] ?? [] as $_funcRef) {
             $content = GeneralUtility::callUserFunction($_funcRef, $_params, $this);
+            $_params['content'] = $content;
         }
         return $this->conf['wrapContentInBaseClass'] ? $this->pi_wrapInBaseClass($content) : $content;
     }


### PR DESCRIPTION
postProcContent-hooks are used to update page content before it is sent
to the browser, e.g. by processing extra item markers.
When a hook is called, the current page content is passed as parameter
$_params and the modified content is returned by the hook.
Unfortunately the $_params-object is not updated in the loop which
calls all hooks. Each hook is called with the initial page content, and
only the return value of the last hook is returned as the overall
result  (i.e. final page content).

This change updates the $_params-object in each iteration, so each hook-
function is called with the updated content of the previous hook. This
ensures that the modifications of all hooks are applied and not only
the modifications of the last hook.