### PR TITLE
Wrong Variable Type

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/10.1/Feature-88602-AllowAdditionalFileProcessors.rst
+++ b/typo3/sysext/core/Documentation/Changelog/10.1/Feature-88602-AllowAdditionalFileProcessors.rst
@@ -18,7 +18,7 @@ To register a new processor, add the following code to :file:`ext_localconf.php`
 
    $GLOBALS['TYPO3_CONF_VARS']['SYS']['fal']['processors']['MyNewImageProcessor'] = [
        'className' => \Vendor\ExtensionName\Resource\Processing\MyNewImageProcessor::class,
-       'before' => 'LocalImageProcessor',
+       'before' => ['LocalImageProcessor'],
    ];
 
 To order the processors, use `before` and `after` statements. TYPO3 will process the file


### PR DESCRIPTION
Given variable for Ordering must be an array: 
'before' => ['']