### PR TITLE
Update Autocomplete widget template ajax url

### DIFF
--- a/typo3/sysext/fluid/Resources/Private/Templates/ViewHelpers/Widget/Autocomplete/Index.html
+++ b/typo3/sysext/fluid/Resources/Private/Templates/ViewHelpers/Widget/Autocomplete/Index.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
 jQuery(function() {
     jQuery("#{id}").autocomplete(<f:format.raw value="{" />
-        source: "{f:widget.uri(action:'autocomplete', ajax: 1)}",
+        source: <f:format.raw>"{f:widget.uri(action:'autocomplete', ajax: 1)}"</f:format.raw>,
         minLength: 2
     });
 });


### PR DESCRIPTION
Update the template to not generate a url containing &amp; which results in not working ajax call.