### PR TITLE
Add example to configuration concepts

### DIFF
--- a/typo3/sysext/rte_ckeditor/Documentation/Configuration/Concepts.rst
+++ b/typo3/sysext/rte_ckeditor/Documentation/Configuration/Concepts.rst
@@ -176,9 +176,12 @@ and per-type basis:
   content elements with Content Type “Bullet list” (CType=bullets).
 
 Of course, any other specific option set via Yaml can be overridden via
-Page TSconfig as well.
+Page TSconfig as well:
 
-.. todo: real world example usages
+.. code-block:: typoscript
+
+   # Allow iframe tag with all attributes and all styles in bodytext field of content elements (Requires additional processing configuration)
+   RTE.config.tt_content.bodytext.editor.config.extraAllowedContent = iframe[*]{*}
 
 The loading order for configuration is:
 


### PR DESCRIPTION
This change adds a real life example to section "Overriding Configuration via Page TSconfig".