### PR TITLE
Changelog title and filename mismatch

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/master/Important-89992-UseNewTranslationServer.rst
+++ b/typo3/sysext/core/Documentation/Changelog/master/Important-89992-UseNewTranslationServer.rst
@@ -1,7 +1,7 @@
 .. include:: ../../Includes.txt
 
 ============================================
-Feature: #89992 - Use new Translation Server
+Important: #89992 - Use new Translation Server
 ============================================
 
 See :issue:`89992`


### PR DESCRIPTION
The changelog "Use new Translation Server" has a title indicating it is a feature,
but has a filename starting with "Important".

Changing only the title now and not the filename because that will not result in broken URL.