### PR TITLE
use strict type comparison for isValueSelected

### DIFF
--- a/typo3/sysext/fluid/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
+++ b/typo3/sysext/fluid/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
@@ -70,10 +70,13 @@ class OptionViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFie
     {
         $selectedValue = $this->renderingContext->getViewHelperVariableContainer()->get(SelectViewHelper::class, 'selectedValue');
         if (is_array($selectedValue)) {
-            return in_array($value, $selectedValue);
+            return in_array((string)$value, $selectedValue, true);
         }
         if ($selectedValue instanceof \Iterator) {
-            return in_array($value, iterator_to_array($selectedValue));
+            return in_array((string)$value, iterator_to_array($selectedValue), true);
+        }
+        if ($selectedValue instanceof \IteratorAggregate) {
+            return in_array((string)$value, iterator_to_array($selectedValue->getIterator()), true);
         }
         return $value == $selectedValue;
     }


### PR DESCRIPTION
\TYPO3\CMS\Fluid\ViewHelpers\Form\SelectViewHelper::isSelected
uses a strict type comparison but the OptionViewHelper does not.

This resulted in funny results when the values were convertable to int like this:
var_dump(in_array(1, ['1-2'])); // prints bool(true)

The value is now converted to a string, just like in the SelectViewHelper,
and then strictly compared.