### PR TITLE
Bugfix: GeneralUtility.php

### DIFF
--- a/typo3/sysext/core/Classes/Utility/GeneralUtility.php
+++ b/typo3/sysext/core/Classes/Utility/GeneralUtility.php
@@ -2099,7 +2099,7 @@ class GeneralUtility
      * and group ownership according to $GLOBALS['TYPO3_CONF_VARS']['SYS']['createGroup']
      *
      * @param string $newFolder Absolute path to folder, see PHP mkdir() function. Removes trailing slash internally.
-     * @return bool TRUE if @mkdir went well!
+     * @return bool TRUE if operation was successful
      */
     public static function mkdir($newFolder)
     {
@@ -2177,7 +2177,7 @@ class GeneralUtility
      *
      * @param string $path Absolute path to folder, see PHP rmdir() function. Removes trailing slash internally.
      * @param bool $removeNonEmpty Allow deletion of non-empty directories
-     * @return bool TRUE if @rmdir went well!
+     * @return bool TRUE if operation was successful
      */
     public static function rmdir($path, $removeNonEmpty = false)
     {


### PR DESCRIPTION
See https://review.typo3.org/c/Packages/TYPO3.CMS/+/61517/5/typo3/sysext/core/Classes/Utility/GeneralUtility.php

This fix made it in Typo3 10.x but Typo3 9.5.x should also be fixed, as it causes some  Doctrine\Common\Annotations\AnnotationException in the backend of Typo3.