### PR TITLE
Replace <style> for compliance with CSP header

### DIFF
--- a/typo3/sysext/redirects/Resources/Public/Icons/Extension.svg
+++ b/typo3/sysext/redirects/Resources/Public/Icons/Extension.svg
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="64px" height="64px" viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
-<path style="fill:#5599FF;" d="M-0.5-0.5h64v64h-64V-0.5z"/>
-<path style="fill:#FFFFFF;" d="M31.9,18.254c3.639,0.008,6.943,1.439,9.385,3.771l1.961-1.959c0.828-0.832,2.25-0.244,2.25,0.932
+<svg version="1.1" id="Layer_1"
+	xmlns="http://www.w3.org/2000/svg"
+	x="0px" y="0px"
+	width="64px" height="64px"
+	viewBox="0 0 64 64">
+<path fill="#5599ff" d="M-0.5-0.5h64v64h-64V-0.5z"/>
+<path fill="#ffffff" d="M31.9,18.254c3.639,0.008,6.943,1.439,9.385,3.771l1.961-1.959c0.828-0.832,2.25-0.244,2.25,0.932
 	v7.363c0,0.729-0.594,1.316-1.32,1.316h-7.359c-1.176,0-1.758-1.42-0.93-2.252l2.289-2.291c-1.695-1.584-3.887-2.469-6.219-2.484
 	c-5.076-0.045-9.354,4.061-9.309,9.303c0.039,4.977,4.072,9.148,9.227,9.148c2.258,0,4.395-0.806,6.082-2.281
 	c0.258-0.228,0.648-0.215,0.898,0.031l2.176,2.18c0.266,0.262,0.254,0.703-0.027,0.953c-2.414,2.18-5.617,3.508-9.129,3.508


### PR DESCRIPTION
SVG is not loaded when the Content-Security-Policy header contains the widely used setting "style-src 'self';" because then the browser must rejects to load external files containing styles. In this case a black rectangle is displayed.
Using attributes instead of styles is compliant with CSP "style-src 'self';" and the file will be loaded.