### PR TITLE
Namespaces for PSR-14 events corrected

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/10.4/Deprecation-88740-ExtFeloginPibasePlugin.rst
+++ b/typo3/sysext/core/Documentation/Changelog/10.4/Deprecation-88740-ExtFeloginPibasePlugin.rst
@@ -41,21 +41,21 @@ All of the hooks have been replaced by equivalent PSR-14 events.
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
 | Pibase hook                                                                       | PSR-14 event                                                         |
 +===================================================================================+======================================================================+
-|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['beforeRedirect']`         | :php:`\TYPO3\CMS\FrontendLogin\Event\Login\BeforeRedirectEvent`      |
+|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['beforeRedirect']`         | :php:`\TYPO3\CMS\FrontendLogin\EventBeforeRedirectEvent`      |
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
-|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['postProcContent']`        | :php:`\TYPO3\CMS\FrontendLogin\Event\Login\ModifyLoginFormViewEvent` |
+|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['postProcContent']`        | :php:`\TYPO3\CMS\FrontendLogin\EventModifyLoginFormViewEvent` |
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
-|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['forgotPasswordMail']`     | :php:`\TYPO3\CMS\FrontendLogin\Event\Login\SendRecoveryEmailEvent`   |
+|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['forgotPasswordMail']`     | :php:`\TYPO3\CMS\FrontendLogin\EventSendRecoveryEmailEvent`   |
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
-|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['password_changed']`       | :php:`\TYPO3\CMS\FrontendLogin\Event\Login\PasswordChangeEvent`      |
+|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['password_changed']`       | :php:`\TYPO3\CMS\FrontendLogin\EventPasswordChangeEvent`      |
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
-|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['login_confirmed']`        | :php:`\TYPO3\CMS\FrontendLogin\Event\Login\LoginConfirmedEvent`      |
+|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['login_confirmed']`        | :php:`\TYPO3\CMS\FrontendLogin\EventLoginConfirmedEvent`      |
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
-|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['login_error']`            | :php:`\TYPO3\CMS\FrontendLogin\Event\Login\LoginErrorOccurredEvent`  |
+|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['login_error']`            | :php:`\TYPO3\CMS\FrontendLogin\EventLoginErrorOccurredEvent`  |
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
-|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['logout_confirmed']`       | :php:`\TYPO3\CMS\FrontendLogin\Event\Login\LogoutConfirmedEvent`     |
+|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['logout_confirmed']`       | :php:`\TYPO3\CMS\FrontendLogin\EventLogoutConfirmedEvent`     |
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
-|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['loginFormOnSubmitFuncs']` | :php:`\TYPO3\CMS\FrontendLogin\Event\Login\ModifyLoginFormViewEvent` |
+|:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['loginFormOnSubmitFuncs']` | :php:`\TYPO3\CMS\FrontendLogin\EventModifyLoginFormViewEvent` |
 +-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
 
 .. index:: Frontend, FullyScanned, ext:felogin


### PR DESCRIPTION
The namespaces for the PSR-14 events are not working. Removed /Login - path since this is not existing.