### PR TITLE
[BUGFIX] Allow to set replyTo email address in ext:felogin

### DIFF
--- a/typo3/sysext/felogin/Classes/Controller/FrontendLoginController.php
+++ b/typo3/sysext/felogin/Classes/Controller/FrontendLoginController.php
@@ -1139,7 +1139,7 @@ class FrontendLoginController extends AbstractPlugin
         }
         $parsedReplyTo = MailUtility::parseAddresses($replyTo);
         if (!empty($parsedReplyTo)) {
-            $mail->replyTo($parsedReplyTo);
+            $mail->replyTo(...$parsedReplyTo);
         }
         // First line is subject
         $messageParts = explode(LF, trim($message), 2);


### PR DESCRIPTION
If the TypoScript variable `plugin.tx_felogin_pi1.replyTo` was set to
an email address, it triggered the following error:
`Symfony\\Component\\Mime\\Exception\\InvalidArgumentException: An address can be an instance of Address or a string (\"array\") given)`