### PR TITLE
Additional configuration for selectCheckBox

### DIFF
--- a/typo3/sysext/backend/Classes/Form/Element/SelectCheckBoxElement.php
+++ b/typo3/sysext/backend/Classes/Form/Element/SelectCheckBoxElement.php
@@ -221,7 +221,11 @@ class SelectCheckBoxElement extends AbstractFormElement
                     }
 
                     if (is_array($group['header'])) {
-                        $html[] = '<div id="' . $groupIdCollapsible . '" class="panel-collapse collapse" role="tabpanel">';
+                        if(is_bool($config['expandAll']) && $config['expandAll']) {
+                            $html[] = '<div id="' . $groupIdCollapsible . '" class="panel-collapse collapse in" role="tabpanel">';
+                        } else {
+                            $html[] = '<div id="' . $groupIdCollapsible . '" class="panel-collapse collapse" role="tabpanel">';
+                        }
                     }
                     $checkboxId = uniqid($groupId);
                     $title = htmlspecialchars($this->getLanguageService()->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.toggleall'));


### PR DESCRIPTION
A client recently required me to automatically expand all the divider of selectCheckBox in typo9.5. For this reason I believe this would be an appropriate addition to the core functionality, adding the ability to put "expandAll" => true (similar to the treeConfig except without a unique parent key) into the TCA to control the expansion of the dividers