### PR TITLE
[!!!][TASK] Set Sys log dateformat to system default

### DIFF
--- a/typo3/sysext/belog/Classes/Controller/BackendLogController.php
+++ b/typo3/sysext/belog/Classes/Controller/BackendLogController.php
@@ -88,7 +88,7 @@ class BackendLogController extends ActionController
     public function initializeListAction()
     {
         if (!isset($this->settings['dateFormat'])) {
-            $this->settings['dateFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['USdateFormat'] ? 'm-d-Y' : 'd-m-Y';
+            $this->settings['dateFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] ;
         }
         if (!isset($this->settings['timeFormat'])) {
             $this->settings['timeFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'];


### PR DESCRIPTION
TYPO3 configuration knows a global date format configuration
within the installation tool. See TYPO3_CONF_VARS/SYS/ddmmyy

Use this global format as the default for Sys log

TYPO3_CONF_VARS/SYS/ddmmyy  is more efficient than
TYPO3_CONF_VARS/SYS/USdateFormat
ddmmyy ( Y-M-D | M-D-Y | D-M-Y)
USdateFormat ( M-D-Y | D-M-Y)