### PR TITLE
[BUGFIX] ISO Date Format Year-M-D with SYS Global Format 

### DIFF
--- a/typo3/sysext/backend/Classes/Controller/BackendController.php
+++ b/typo3/sysext/backend/Classes/Controller/BackendController.php
@@ -349,7 +349,19 @@ class BackendController
     {
         $beUser = $this->getBackendUser();
         // Needed for FormEngine manipulation (date picker)
-        $dateFormat = ($GLOBALS['TYPO3_CONF_VARS']['SYS']['USdateFormat'] ? ['MM-DD-YYYY', 'HH:mm MM-DD-YYYY'] : ['DD-MM-YYYY', 'HH:mm DD-MM-YYYY']);
+        // ISO 8601:2000 Datetime format is Year-Month-Day.
+        // TYPO3 configuration knows a global date format configuration
+        // See TYPO3_CONF_VARS/SYS/ddmmyy
+        // If first letter of $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] === 'Y' or 'y'
+        // date format will be ISO format
+        if (strtoupper(substr($GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'], 0, 1)) === 'Y') {
+            // Some countries use date format 'Year-Month-Day'
+            $dateFormat = ['YYYY-MM-DD', 'YYYY-MM-DD HH:mm'];
+        } elseif ($GLOBALS['TYPO3_CONF_VARS']['SYS']['USdateFormat']) {
+            $dateFormat = ['MM-DD-YYYY', 'HH:mm MM-DD-YYYY'];
+        } else {
+            $dateFormat = ['DD-MM-YYYY', 'HH:mm DD-MM-YYYY'];
+        }
         $this->pageRenderer->addInlineSetting('DateTimePicker', 'DateFormat', $dateFormat);
 
         // If another page module was specified, replace the default Page module with the new one

--- a/typo3/sysext/backend/Resources/Public/JavaScript/FormEngine.js
+++ b/typo3/sysext/backend/Resources/Public/JavaScript/FormEngine.js
@@ -1344,7 +1344,7 @@ define(['jquery',
    * Sets some options and registers the DOMready handler to initialize further things
    *
    * @param {String} browserUrl
-   * @param {Number} mode
+   * @param {String} mode
    */
   FormEngine.initialize = function(browserUrl, mode) {
     DocumentSaveActions.getInstance().addPreSubmitCallback(function() {
@@ -1355,7 +1355,7 @@ define(['jquery',
     });
 
     FormEngine.browserUrl = browserUrl;
-    FormEngine.Validation.setUsMode(mode);
+    FormEngine.Validation.setDateFormat(mode);
 
     $(function() {
       FormEngine.initializeEvents();


### PR DESCRIPTION
TYPO3 configuration knows a global date format configuration
within the installation tool. See TYPO3_CONF_VARS/SYS/ddmmyy

Most countries prefer the Year-Month-Day date format and
not the UK/US style Month-Day->Year.

Change the initialization of the DateTimePicker accordingly.