### PR TITLE
[BUGFIX] Remove unnecessary pre-checks on "transport_spool_filepath"

### DIFF
--- a/typo3/sysext/core/Classes/Mail/TransportFactory.php
+++ b/typo3/sysext/core/Classes/Mail/TransportFactory.php
@@ -185,8 +185,8 @@ class TransportFactory implements SingletonInterface, LoggerAwareInterface
         switch ($mailSettings['transport_spool_type']) {
             case self::SPOOL_FILE:
                 $path = GeneralUtility::getFileAbsFileName($mailSettings['transport_spool_filepath']);
-                if (empty($path) || !file_exists($path) || !is_writable($path)) {
-                    throw new \RuntimeException('The Spool Type filepath must be available and writeable for TYPO3 in order to be used. Be sure that it\'s not accessible via the web.', 1518558797);
+                if (empty($path)) {
+                    throw new \RuntimeException('The Spool Type filepath must be configured for TYPO3 in order to be used. Be sure that it\'s not accessible via the web.', 1518558797);
                 }
                 $spool = GeneralUtility::makeInstance(FileSpool::class, $path);
                 break;


### PR DESCRIPTION
FileSpool uses GeneralUtility::mkdir_deep() if path does not exist.
mkdir_deep() also tries to fix permissions. Even if this fails, there are further writable-checks down the line.