### PR TITLE
[BUGFIX] Allow longer values in index_stat_word

### DIFF
--- a/typo3/sysext/indexed_search/ext_tables.sql
+++ b/typo3/sysext/indexed_search/ext_tables.sql
@@ -157,7 +157,7 @@ CREATE TABLE index_config (
 #
 CREATE TABLE index_stat_word (
   uid int(11) NOT NULL auto_increment,
-  word varchar(30) DEFAULT '' NOT NULL,
+  word varchar(255) DEFAULT '' NOT NULL,
   index_stat_search_id int(11) DEFAULT '0' NOT NULL,
   tstamp int(11) DEFAULT '0' NOT NULL,
   pageid int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
A varchar length of 30 seems not reasonable. This limit gets hit quite frequently. Allow up to 255 characters without affecting storage-space nor performance.

Resolves: #92323
Releases: master, 10.4, 9.5