### PR TITLE
[Bugfix] switch extensionname and pluginname

### DIFF
--- a/typo3/sysext/form/Documentation/I/Concepts/FrontendRendering/Index.rst
+++ b/typo3/sysext/form/Documentation/I/Concepts/FrontendRendering/Index.rst
@@ -294,8 +294,8 @@ Render through FLUIDTEMPLATE (without controller)
            settings {
                persistenceIdentifier = EXT:my_site_package/Resources/Private/Forms/MyForm.yaml
            }
-           extbase.pluginName = Form
-           extbase.controllerExtensionName = Formframework
+           extbase.pluginName = Formframework
+           extbase.controllerExtensionName = Form
            extbase.controllerName = FormFrontend
            extbase.controllerActionName = perform
        }


### PR DESCRIPTION
these two parameters are switched in versions master, 10.4, 9.5, 8.7