### PR TITLE
Add deprecation warning to Widget ViewHelper

### DIFF
--- a/typo3/sysext/fluid/Classes/ViewHelpers/Widget/PaginateViewHelper.php
+++ b/typo3/sysext/fluid/Classes/ViewHelpers/Widget/PaginateViewHelper.php
@@ -22,6 +22,11 @@ use TYPO3\CMS\Fluid\ViewHelpers\Widget\Controller\PaginateController;
 
 /**
  * This ViewHelper renders a Pagination of objects.
+ * 
+ * .. warning::
+ *
+ *   Using widgets is deprecated and all fluid widgets will be removed in a future release.
+ *   See :doc:`t3core:Changelog/master/Breaking-92529-AllFluidWidgetFunctionalityRemoved`
  *
  * Examples
  * ========


### PR DESCRIPTION
If possible, I'd like to propose this warning on top of the documentation for the Widget ViewHelper, because I did not find a deprecation notice (except for the Autocomplete ViewHelper) in the Core Changelog.

Developers using the current 10.4 version should be urged in all appropriate places not to start using Fluid widgets, not only in the Core Changelog.