### PR TITLE
Change Hook registration in Changelog

### DIFF
--- a/typo3/sysext/core/Documentation/Changelog/9.2/Feature-71911-AddConstraintHookInDatabaseRecordListMakeSearchString.rst
+++ b/typo3/sysext/core/Documentation/Changelog/9.2/Feature-71911-AddConstraintHookInDatabaseRecordListMakeSearchString.rst
@@ -22,7 +22,7 @@ An example implementation could look like this:
 .. code-block:: php
 
    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][\TYPO3\CMS\Recordlist\RecordList\DatabaseRecordList::class]['makeSearchStringConstraints'][1313131313] =
-      \MyVendor\MySite\Hooks\DatabaseRecordListHook::class . '->makeSearchStringConstraints';
+      '\\MyVendor\\MySite\\Hooks\\DatabaseRecordListHook';
 
 
 :file:`EXT:my_site/Classes/Hooks/DatabaseRecordListHook.php`


### PR DESCRIPTION
On 10.4 using `autowire`, registering the hook as described lead to an error stating that the class could not be found.
Also, as far as I can see, the name of the method is being checked for in [Line 3391 of DatabaseRecordList.php](https://github.com/TYPO3/TYPO3.CMS/blob/2bef387e1a65de6218de6b32b7edb57668c37cff/typo3/sysext/recordlist/Classes/RecordList/DatabaseRecordList.php#L3391).