### PR TITLE
[TASK] Update link to v11 Changelog

### DIFF
--- a/typo3/sysext/fluid/Classes/ViewHelpers/Widget/PaginateViewHelper.php
+++ b/typo3/sysext/fluid/Classes/ViewHelpers/Widget/PaginateViewHelper.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Fluid\ViewHelpers\Widget\Controller\PaginateController;
  * .. warning::
  *
  *   Using widgets is deprecated and all fluid widgets will be removed in a future release.
- *   See :doc:`t3core:Changelog/master/Breaking-92529-AllFluidWidgetFunctionalityRemoved`
+ *   See :doc:`t3core:Changelog/11.0/Breaking-92529-AllFluidWidgetFunctionalityRemoved`
  *
  * Examples
  * ========


### PR DESCRIPTION
Since the 11.0 changelog was moved from master to 11.0,
this link was no longer working.

Releases: 10.4
Related: #92917