### PR TITLE
[BUGFIX] Non admin can't see xMOD_alt_doc.php shortcuts

### DIFF
--- a/typo3/sysext/backend/Classes/Backend/Shortcut/ShortcutRepository.php
+++ b/typo3/sysext/backend/Classes/Backend/Shortcut/ShortcutRepository.php
@@ -723,7 +723,7 @@ class ShortcutRepository
      */
     protected function extractPageIdFromShortcutUrl(string $url): int
     {
-        return (int)preg_replace('/.*[\\?&]id=([^&]+).*/', '$1', $url);
+        return (int)preg_replace('/.*[\\?&]id=([^&]+).*/', '$1', urldecode($url));
     }
 
     /**


### PR DESCRIPTION
Prevent id= not found in the url ...returnUrl=*encoded*...