### PR TITLE
Escape `colPos` to fix the example for other dbms

### DIFF
--- a/typo3/sysext/fluid_styled_content/Documentation/Installation/InsertingContentPageTemplate/Index.rst
+++ b/typo3/sysext/fluid_styled_content/Documentation/Installation/InsertingContentPageTemplate/Index.rst
@@ -33,7 +33,7 @@ Based on the FLUIDTEMPLATE content object (cObj)
          table = tt_content
          select {
             orderBy = sorting
-            where = colPos={register:colPos}
+            where = {#colPos}={register:colPos}
             where.insertData = 1
          }
       }


### PR DESCRIPTION
`colPos` must be escaped as `{#colPos}` in order to make the database query work on database systems with case sensivity (e.g. PostgreSQL)

See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.7/Important-80506-DbalCompatibleFieldQuotingInTypoScript.html and https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/Functions/Select.html#quoting-of-fields