### PR TITLE
Update comment to remove never used typo3_conf_var "transport_smtp_port"

### DIFF
--- a/typo3/sysext/core/Classes/Mail/Mailer.php
+++ b/typo3/sysext/core/Classes/Mail/Mailer.php
@@ -141,8 +141,7 @@ class Mailer implements MailerInterface
      * Used options:
      * $TYPO3_CONF_VARS['MAIL']['transport'] = 'smtp' | 'sendmail' | 'null' | 'mbox'
      *
-     * $TYPO3_CONF_VARS['MAIL']['transport_smtp_server'] = 'smtp.example.org';
-     * $TYPO3_CONF_VARS['MAIL']['transport_smtp_port'] = '25';
+     * $TYPO3_CONF_VARS['MAIL']['transport_smtp_server'] = 'smtp.example.org:25';
      * $TYPO3_CONF_VARS['MAIL']['transport_smtp_encrypt'] = FALSE; # requires openssl in PHP
      * $TYPO3_CONF_VARS['MAIL']['transport_smtp_username'] = 'username';
      * $TYPO3_CONF_VARS['MAIL']['transport_smtp_password'] = 'password';


### PR DESCRIPTION
remove the comment with transport_smtp_port as it was never used within typo3 core. Introduced way back in https://forge.typo3.org/attachments/15596, but already documented that the port has to be written within transport_smtp_server with a colon. Update the line of transport_smtp_server to a proper example by adding colon an port.