### PR TITLE
Fixed missing is_array check in setValueByPath

### DIFF
--- a/typo3/sysext/core/Classes/Utility/ArrayUtility.php
+++ b/typo3/sysext/core/Classes/Utility/ArrayUtility.php
@@ -289,7 +289,7 @@ class ArrayUtility
                 throw new \RuntimeException('Invalid path segment specified', 1341406846);
             }
             // Create cell if it doesn't exist
-            if (!array_key_exists($segment, $pointer)) {
+            if (is_array($pointer) && !array_key_exists($segment, $pointer)) {
                 $pointer[$segment] = [];
             }
             // Set pointer to new cell


### PR DESCRIPTION
PHP Warning: array_key_exists() expects parameter 2 to be array, null given in /var/www/public/typo3/sysext/core/Classes/Utility/ArrayUtility.php line 297